### PR TITLE
Reduce the lifetime of certificates to 366 days.

### DIFF
--- a/CommModule/client.pl
+++ b/CommModule/client.pl
@@ -444,7 +444,7 @@ sub calculateDays($)
     my @sum = $dbh->selectrow_array("select sum(`points`) as `total` from `notary` where `to`='".$_[0]."' and `deleted`=0 group by `to`");
     SysLog("Summe: $sum[0]\n") if($debug);
 
-    return ($sum[0]>=50)?730:180;
+    return ($sum[0]>=50)?366:180;
   }
   return 180;
 }


### PR DESCRIPTION
This commit fixes #1482 by setting the lifetime of certificates to 366
days. Updates to the user documentation and/or CPS might be required and
there is no distinction between client and server certificates because
the type of certificate is not known at that location of the code.

Fixes #1482, Relates to #1494, #775