### PR TITLE
Added two environment variables, MODE and MX_WHITELIST.

### DIFF
--- a/includes/general.php
+++ b/includes/general.php
@@ -554,10 +554,27 @@
 
 	function checkEmail($email)
 	{
+		if ( is_devmode() ) {
+			return "OK" ;
+		}
+
 		$myemail = mysql_real_escape_string($email);
 		if(preg_match("/^([a-zA-Z0-9])+([a-zA-Z0-9\+\._-])*@([a-zA-Z0-9_-])+([a-zA-Z0-9\._-]+)+$/" , $email))
 		{
 			list($username,$domain)=explode('@',$email,2);
+
+			/*
+			* Check if the MX_WHITELIST environment variable is set,
+			* and, if so, see if it contains the domain name for
+			* this e-mail address.
+			*/
+			if ( strlen( getenv( "MX_WHITELIST" )) > 0 ) {
+				$whitelist_arr = explode( ",", getenv( "MX_WHITELIST" )) ;
+				if ( in_array( $domain, $whitelist_arr ) ) {
+					return "OK" ;
+				}
+			}
+
 			$mxhostrr = array();
 			$mxweight = array();
 			if( !getmxrr($domain, $mxhostrr, $mxweight) ) {
@@ -592,10 +609,10 @@
 			{
 				$fp_opt = array(
 					'ssl' => array(
-						'verify_peer'   => false,	// Opportunistic Encryption
-						'verify_peer_name'   => false,	// Opportunistic Encryption
-						)
-					);
+					'verify_peer'   => false,	// Opportunistic Encryption
+					'verify_peer_name'   => false,	// Opportunistic Encryption
+					)
+				);
 				$fp_ctx = stream_context_create($fp_opt);
 				$fp = @stream_socket_client("tcp://$domain:25",$errno,$errstr,5,STREAM_CLIENT_CONNECT,$fp_ctx);
 				if($fp)
@@ -678,7 +695,7 @@
 			}
 		}
 		$query = "insert into `pinglog` set `when`=NOW(), `uid`='".intval($_SESSION['profile']['id'])."',
-				`email`='$myemail', `result`='Failed to make a connection to the mail server'";
+			`email`='$myemail', `result`='Failed to make a connection to the mail server'";
 		mysql_query($query);
 		return _("Failed to make a connection to the mail server");
 	}
@@ -818,6 +835,40 @@
 		$text=preg_replace("/[^\w-.@]/","",$text);
 		return($text);
 	}
+
+	       /**
+	        * Test whether the MODE environment variable
+	        * is set to DEV.
+	        */
+	       function is_devmode() {
+	               return( getenv( "MODE" ) == "DEV" ) ;
+       }
+
+       /**
+        * Test whether the MODE environment variable
+        * is set to PROD.
+        *
+        * If it is not set at all, assume PROD.
+        */
+       function is_prodmode() {
+	               $prod_mode == false ;
+
+	               $is_prod = getenv( "MODE" ) == "PROD" ;
+	               if ( ! $is_prod && ! ( getenv( "MODE" ) == "DEV" ) ) {
+		                       $prod_mode = true ;
+		               }
+
+               return $prod_mode ;
+       }
+
+       /**
+        * Test whether the MODE environment variable
+        * is set to TEST.
+        */
+       function is_testmode() {
+	               return ( getenv( "MODE" ) == "TEST" ) ;
+       }
+
 
 
 	// returns text message to be shown to the user given the result of is_no_assurer


### PR DESCRIPTION
MODE can have the values DEV, TEST or PROD, while MX_WHITELIST
contains a comma-separated list of domains that will not be checked.

The updated "Apache Environment Variables" file will look like:

### Variable | Description | Default value
### ---- | ---- | ----
### `DEPLOYMENT_NAME` | name of the specific instance | `"CAcert.org Website"`
### `CRT_DIRECTORY`* | directory where certificates are stored | none
### `CSR_DIRECTORY`* | directory where CSRs are stored | none
### `MYSQL_WEBDB_DATABASE`* | database name | none
### `MYSQL_WEBDB_HOSTNAME`* | database hostname | none
### `MYSQL_WEBDB_PASSWORD`* | database password | none
### `MYSQL_WEBDB_USER`* | database user name | none
### `RETURN_ADDRESS`* | return address (Errors-To header) for outgoing mails | none
### `SMTP_HOST`* | mail server to use for outgoing mails | none
### `SMTP_PORT` | port of the mail server | `25`
### `INSECURE_PORT` | port to use for http | none (defaults to 80)
### `SECURE_PORT` | port to use for https | none (default to 443)
### `DEFAULT_HOSTNAME`* | hostname for the default URL | none
### `SECURE_HOSTNAME`* | hostname for client certificate authentication | none
### `TVERIFY_HOSTNAME`* | hostname for tverify | none
###
### `MODE`* | Flag to indicate that the code is working in Production or Development
###             one of DEV, TEST or PROD
###
### 'MX_WHITELIST' * | Comma-separated list of domain names that will not be checked for MX connectivity.
###             For example "example.com,cacert.org"  Commas only, no spaces.
### 
### Environment variables marked with an asterisk (*) need to be defined explicitly.


SetEnv MYSQL_WEBDB_DATABASE cacert
SetEnv MYSQL_WEBDB_HOSTNAME localhost
SetEnv MYSQL_WEBDB_PASSWORD anotherhardpassword
SetEnv MYSQL_WEBDB_USER cacertapplication
SetEnv RETURN_ADDRESS root
SetEnv SMTP_HOST localhost
SetEnv CSR_DIRECTORY /tmp/csr
SetEnv CRT_DIRECTORY /tmp/crt
SetEnv DEFAULT_HOSTNAME cacert-test.local
SetEnv SECURE_HOSTNAME secure.cacert-test.local
SetEnv TVERIFY_HOSTNAME cacert-test.local

SetEnv MODE DEV
SetEnv MX_WHITELIST cacert.org,example.com
